### PR TITLE
Bump Rust edition and dependencies as well as misc updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
+.devcontainer/
+
 # Build files
 /target
 Cargo.lock
-
-# Editor files
-\#*#
-.#*
-*~

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "clone_cell"
-version = "0.4.0"
-edition = "2018"
-authors = ["Vektorlynk"]
+version = "0.4.1"
+edition = "2021"
+authors = ["vchlin"]
 license = "MIT OR Apache-2.0"
 description = "A Cell that works with a restrictive form of Clone"
-repository = "https://github.com/Vektorlynk/clone_cell"
+repository = "https://github.com/vchlin/clone_cell"
 documentation = "https://docs.rs/clone_cell"
 readme = "README.md"
 keywords = ["clone", "cell", "mutability"]
@@ -18,9 +18,7 @@ derive = ["clone_cell_derive"]
 clone_cell_derive = { version = "0.2.0", path = "derive", optional = true }
 
 [dev-dependencies]
-trybuild = "1.0.45"
+trybuild = "1.0.101"
 
 [workspace]
-members = [
-    "derive",
-]
+members = ["derive"]

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Vektorlynk
+Copyright (c) 2021-2025 vchlin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "clone_cell_derive"
-version = "0.2.0"
-edition = "2018"
-authors = ["Vektorlynk"]
+version = "0.2.1"
+edition = "2021"
+authors = ["vchlin"]
 license = "MIT OR Apache-2.0"
 description = "Proc macro for clone_cell"
-repository = "https://github.com/Vektorlynk/clone_cell"
+repository = "https://github.com/vchlin/clone_cell"
 documentation = "https://docs.rs/clone_cell_derive"
 
 [lib]
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.29"
-quote = "1.0.9"
+proc-macro2 = "1.0.92"
+quote = "1.0.38"
 syn = "2.0.94"
 synstructure = "0.13.1"


### PR DESCRIPTION
- Bump package versions.
- Bump Rust edition and dependency versions.
- Update copyright year.
- Update `Cell::swap` to match the behavior of `std::cell::Cell::swap`.